### PR TITLE
Use roomname as callstats conference id

### DIFF
--- a/modules/statistics/CallStats.js
+++ b/modules/statistics/CallStats.js
@@ -102,9 +102,7 @@ var CallStats = _try_catch(function(jingleSession, Settings, options) {
 
         this.userID = Settings.getCallStatsUserName();
 
-    //FIXME:  change it to something else (maybe roomName)
-        var location = window.location;
-        this.confID = location.hostname + location.pathname;
+        this.confID = this.session.room.roomjid;
 
         //userID is generated or given by the origin server
         callStats.initialize(options.callStatsID,


### PR DESCRIPTION
This will make the callstats conference id consistent across platform
