### PR TITLE
handle missing temasys

### DIFF
--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -847,6 +847,15 @@ var RTCUtils = {
 
                 //AdapterJS.WebRTCPlugin.setLogLevel(
                 //    AdapterJS.WebRTCPlugin.PLUGIN_LOG_LEVELS.VERBOSE);
+
+                AdapterJS.WebRTCPlugin.isPluginInstalled(
+                  AdapterJS.WebRTCPlugin.pluginInfo.prefix,
+                  AdapterJS.WebRTCPlugin.pluginInfo.plugName,
+                  function temasysIsInstalled(){},
+                  function temasysNotInstalled() {
+                    reject(new Error("Temasys plugin is not installed"));
+                  });
+
                 var self = this;
                 AdapterJS.webRTCReady(function () {
 


### PR DESCRIPTION
This addresses the issue where `LibJitsiMeet.init()` returns a promise that doesn't ever resolve or reject when on IE11 without Temasys.