### PR TITLE
Fix plugin detection in Safari

### DIFF
--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -855,7 +855,7 @@ var RTCUtils = {
                 AdapterJS.WebRTCPlugin.isPluginInstalled(
                   AdapterJS.WebRTCPlugin.pluginInfo.prefix,
                   AdapterJS.WebRTCPlugin.pluginInfo.plugName,
-                  null,
+                  AdapterJS.WebRTCPlugin.pluginInfo.type,
                   function temasysIsInstalled(){},
                   function temasysNotInstalled(e) {
                     console.error(e.message);


### PR DESCRIPTION
AdapterJS uses the plugin type when determining whether or not the plugin is installed in non-IE browsers