### PR TITLE
CallStats User Name Setter

### DIFF
--- a/modules/settings/Settings.js
+++ b/modules/settings/Settings.js
@@ -94,8 +94,8 @@ class Settings {
     }
 
     /**
-     * Returns fake username for callstats
-     * @returns {string} fake username for callstats
+     * Returns username for callstats
+     * @returns {string} username for callstats
      */
     getCallStatsUserName () {
         return this.callStatsUserName;

--- a/modules/settings/Settings.js
+++ b/modules/settings/Settings.js
@@ -85,6 +85,15 @@ class Settings {
     }
 
     /**
+     * Sets the callstats username
+     * @param {string} userName user name for callstats
+     */
+    setCallStatsUserName (userName) {
+        this.callStatsUserName = userName;
+        this.save();
+    }
+
+    /**
      * Returns fake username for callstats
      * @returns {string} fake username for callstats
      */


### PR DESCRIPTION
Adds a setter to be able to set the CallStats username. Since the CallStats username is generated in the constructor, if a username hasn't been set in local storage from a previous conference, CallStats will see a randomly generated username. 